### PR TITLE
Add commentstring setting to ftplugin. Enables tComment to work out of the box with vim-emblem.

### DIFF
--- a/ftplugin/emblem.vim
+++ b/ftplugin/emblem.vim
@@ -14,3 +14,4 @@ setlocal smartindent
 
 setlocal formatoptions=q
 setlocal comments=:/
+setlocal commentstring=/\ %s


### PR DESCRIPTION
vim-emblem does not work properly with the tComment plugin because it does not set the `commentstring` option, which tcomment uses to define a comment style in the absence of an explicit call to tcomment's [`tComment#DefineType#`](https://github.com/tomtom/tcomment_vim/blob/master/doc/tcomment.txt). A line is added to ftplugin/emblem.vim to solve this problem.
